### PR TITLE
Override Enterprise_PageCache_Model_Cookie 

### DIFF
--- a/app/code/community/Etailer/SecureCookie/Helper/Data.php
+++ b/app/code/community/Etailer/SecureCookie/Helper/Data.php
@@ -26,4 +26,50 @@
  */
 class Etailer_SecureCookie_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    /**
+     * XML path to cookie config "secure"
+     */
+    const XML_PATH_COOKIE_SECURE = 'web/cookie/cookie_secure';
+
+    /**
+     * Store object
+     *
+     * @var Mage_Core_Model_Store|null
+     */
+    protected $_store;
+
+    /**
+     * Check for a secure frontend
+     *
+     * This only applies if
+     *
+     * 1. The secure cookie Option is turned on in the store config.
+     * 2. "Use secure urls in Frontend" is turned on in the store config
+     * 3. The unsecure base URL is a https:// url
+     *
+     * @return boolean
+     */
+    public function checkSecureFrontend()
+    {
+        $store = $this->getStore();
+        if (!$store->getConfig(self::XML_PATH_COOKIE_SECURE) || !$store->getConfig(Mage_Core_Model_Store::XML_PATH_SECURE_IN_FRONTEND)) {
+            return false;
+        }
+
+        $baseLinkUrl = $store->getConfig(Mage_Core_Model_Store::XML_PATH_UNSECURE_BASE_LINK_URL);
+        return (substr($baseLinkUrl, 0, 8) == 'https://');
+    }
+
+    /**
+     * Retrieve Store object
+     *
+     * @return Mage_Core_Model_Store
+     */
+    public function getStore()
+    {
+        if (is_null($this->_store)) {
+            $this->_store = Mage::app()->getStore();
+        }
+        return $this->_store;
+    }
 }

--- a/app/code/community/Etailer/SecureCookie/Model/Enterprise/Cookie.php
+++ b/app/code/community/Etailer/SecureCookie/Model/Enterprise/Cookie.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * This file is part of the mage-secure-cookie Magento extension.
- * 
+ *
  * mage-secure-cookie is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * mage-secure-cookie is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with mage-secure-cookie.  If not, see <http://www.gnu.org/licenses/>.
  *
@@ -22,9 +22,9 @@
  */
 
 /**
- * Mage core cookie overwrite to secure the frontend cookie
+ * Mage core cookie overwrite to secure the cache cookies
  */
-class Etailer_SecureCookie_Model_Cookie extends Mage_Core_Model_Cookie
+class Etailer_SecureCookie_Model_Enterprise_Cookie extends Enterprise_PageCache_Model_Cookie
 {
     /**
      * @see Mage_Core_Model_Cookie::isSecure()

--- a/app/code/community/Etailer/SecureCookie/etc/config.xml
+++ b/app/code/community/Etailer/SecureCookie/etc/config.xml
@@ -25,7 +25,7 @@
 <config>
     <modules>
         <Etailer_SecureCookie>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <description>This module allows to secure the frontend cookie when running the whole store on https</description>
         </Etailer_SecureCookie>
     </modules>
@@ -37,6 +37,11 @@
                     <cookie>Etailer_SecureCookie_Model_Cookie</cookie>
                 </rewrite>
             </core>
+            <enterprise_pagecache>
+                <rewrite>
+                    <cookie>Etailer_SecureCookie_Model_Enterprise_Cookie</cookie>
+                </rewrite>
+            </enterprise_pagecache>
         </models>
         
         <helpers>


### PR DESCRIPTION
Enterprise_PageCache_Model_Cookie extends Mage_Core_Model_Cookie so it must be overridden as well to address the cookies set by the Enterprise_PageCache module, namely the CART cookie, which is not secure if it is set by Enterprise_PageCache_Model_Observer::registerQuoteChange.
